### PR TITLE
support setting bcrypt cost from yaml config

### DIFF
--- a/lib/Dancer2/Plugin/Passphrase/Core.pm
+++ b/lib/Dancer2/Plugin/Passphrase/Core.pm
@@ -72,8 +72,11 @@ sub _merge_options {
     if ( $algorithm eq 'Bcrypt' ) {
         $settings->{'scheme'} = 'CRYPT';
         $settings->{'type'}   = '2a';
-        $settings->{'cost'} =
-          defined $settings->{'cost'} ? $settings->{'cost'} : 4;
+
+        unless ( defined $settings->{'cost'} ) {
+            $settings->{'cost'} = $self->{'Bcrypt'}{'cost'} || 4;
+        }
+
         $settings->{'cost'}   = 31 if $settings->{'cost'} > 31;
         $settings->{'cost'}   = sprintf '%02d', $settings->{'cost'};
     }


### PR DESCRIPTION
In the `Configuration` section of the documentation, the following YAML example is provided:
```
plugins:
    Passphrase:
        algorithm: Bcrypt
        Bcrypt:
            cost: 8
```
However, `Core.pm` does not attempt to pull the cost configuration directive from the config file. This commit corrects this oversight.