### PR TITLE
fix example for Bcrypt configuration in POD

### DIFF
--- a/lib/Dancer2/Plugin/Passphrase.pm
+++ b/lib/Dancer2/Plugin/Passphrase.pm
@@ -339,9 +339,7 @@ a strong psuedo-random salt.
     plugins:
         Passphrase:
             algorithm: Bcrypt
-
-            Bcrypt:
-                cost: 8
+            cost: 8
 
 
 =head2 Storage in a database


### PR DESCRIPTION
at the moment settings for 'Bcrypt' subsection is not supported
the example may obscure configuration process
 and even lead to use of insecure settings (which are defaults now)